### PR TITLE
rename_column(item.category_id)

### DIFF
--- a/db/migrate/20200305015859_create_items.rb
+++ b/db/migrate/20200305015859_create_items.rb
@@ -10,7 +10,7 @@ class CreateItems < ActiveRecord::Migration[5.2]
       t.integer :price, null: false
       t.integer :saler_id, null: false, foreign_key: true
       t.integer :buyer_id, foreign_key: true
-      t.integer :categ_idory, null: false, foreign_key: true
+      t.integer :category_id, null: false, foreign_key: true
       t.string :size
       t.integer :brand_id, foreign_key: true
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2020_03_05_015859) do
     t.integer "price", null: false
     t.integer "saler_id", null: false
     t.integer "buyer_id"
-    t.integer "categ_idory", null: false
+    t.integer "category_id", null: false
     t.string "size"
     t.integer "brand_id"
     t.datetime "created_at", null: false


### PR DESCRIPTION
# what
itemテーブルのcategory_idの名称が誤っていたため修正
本番環境にてrollbackを行い、migrateすることで修正されると思われる。